### PR TITLE
feat: attempt to add a fediwall listening to Snakemake hashtags

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -26,6 +26,56 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      
+      - name: Download and setup Fediwall
+        run: |
+          # Download latest fediwall release
+          curl -L https://github.com/defnull/fediwall/releases/latest/download/fediwall.zip -o fediwall.zip
+          unzip fediwall.zip -d fediwall-temp
+          
+          # Create fediwall directory in build
+          mkdir -p build/fediwall
+          cp -r fediwall-temp/* build/fediwall/
+          
+          # Create custom config for Snakemake hashtag
+          cat > build/fediwall/wall-config.json << 'EOF'
+          {
+            "title": "Snakemake Community Wall",
+            "subtitle": "Follow the #Snakemake hashtag on the Fediverse",
+            "hashtags": [
+              "snakemake",
+              "SnakemakeHackathon",
+              "SnakemakeHackathon2025",
+              "SnakemakeHackathon2026",
+              "SnakemakeHackathon2027",
+              "SnakemakeWrapper",
+              "SnakemakeWrappers",
+              "Snakemake_Wrapper",
+              "Snakemake_Wrappers"
+            ],
+            "accounts": [],
+            "servers": [
+              "mastodon.social",
+              "fosstodon.org",
+              "fediscience.org",
+              "scholar.social",
+              "genomic.social"
+            ],
+            "theme": "auto",
+            "autorefresh": 30,
+            "showboosts": true,
+            "showreplies": false,
+            "showsensitive": false
+          }
+          EOF
+          
+          # Clean up
+          rm -rf fediwall-temp fediwall.zip
+      
       - name: locosopa
         uses: koesterlab/locosopa@main
         with:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -33,9 +33,22 @@ jobs:
       
       - name: Download and setup Fediwall
         run: |
-          # Download latest fediwall release
-          curl -L https://github.com/defnull/fediwall/releases/latest/download/fediwall.zip -o fediwall.zip
-          unzip fediwall.zip -d fediwall-temp
+          # Download specific fediwall release with checksum verification
+          FEDI_WALL_VERSION="v1.4.0"  # bump deliberately
+          FEDI_WALL_SHA256="9aeca19df37e1c872efa0e8047660eb15cfe24f8b14e5c198a20d966e7e456bc"
+          curl -fL "https://github.com/defnull/fediwall/releases/download/${FEDI_WALL_VERSION}/fediwall-1.4.0.tgz" -o fediwall.tgz
+          
+          # Double-check with explicit verification
+          ACTUAL_SHA256=$(sha256sum fediwall.tgz | cut -d' ' -f1)
+          if [ "${ACTUAL_SHA256}" != "${FEDI_WALL_SHA256}" ]; then
+            echo "ERROR: SHA256 checksum verification failed!"
+            echo "Expected: ${FEDI_WALL_SHA256}"
+            echo "Actual:   ${ACTUAL_SHA256}"
+            exit 1
+          fi
+          echo "✓ SHA256 checksum verification passed"
+          mkdir -p fediwall-temp
+          tar -xzf fediwall.tgz -C fediwall-temp --strip-components=1
           
           # Create fediwall directory in build
           mkdir -p build/fediwall
@@ -74,7 +87,7 @@ jobs:
           EOF
           
           # Clean up
-          rm -rf fediwall-temp fediwall.zip
+          rm -rf fediwall-temp fediwall.tgz
       
       - name: locosopa
         uses: koesterlab/locosopa@main

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -23,6 +23,8 @@ header:
   links:
     - text: Docs
       url: https://snakemake.readthedocs.io
+    - text: Community Wall
+      url: /fediwall/
     - text: Github
       url: https://github.com/snakemake
     - text: Mastodon


### PR DESCRIPTION
Hi,

This is an attempt to produce a fediwall extension to the Snakemake homepage. If it works, and I have NO idea, it will be under https://snakemake.readthedocs.io/fediwall and - in a 2nd stage - may replace the personalized Mastodon link.

It currently should listen to the following hashtags (hashtags are not case sensitive, they do not allow a regex either):

- snakemake 
- SnakemakeHackathon
- SnakemakeHackathon2025
- SnakemakeHackathon2026
- SnakemakeHackathon2027
- SnakemakeWrapper
- SnakemakeWrappers
- Snakemake_Wrapper
- Snakemake_Wrappers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a "Community Wall" link to the site header navigation for quick access from the main menu.

- Chores
  - CI pipeline now prepares and embeds static community-wall assets and a default wall configuration during build, ensuring the wall is included and ready in production builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->